### PR TITLE
Loosen dependency on administrate

### DIFF
--- a/administrate-materialize-theme.gemspec
+++ b/administrate-materialize-theme.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
 
   spec.files = Dir["{app,lib}/**/*", "MIT-LICENSE", "Rakefile", "README.md"]
 
-  spec.add_runtime_dependency 'administrate', '~> 0.14.0'
+  spec.add_runtime_dependency 'administrate', '~> 0.14'
 
   spec.add_development_dependency 'activestorage', '~> 6.0'
   spec.add_development_dependency 'capybara', '~> 3.33'


### PR DESCRIPTION
Hi! This pull loosens the dependency on administrate so newer versions of administrate can be used.

I was using version 0.15 and wasn't able to install this theme.