### PR TITLE
Upgrade administrate dependency minimum version from 0.14 to 0.17

### DIFF
--- a/administrate-materialize-theme.gemspec
+++ b/administrate-materialize-theme.gemspec
@@ -27,6 +27,6 @@ Gem::Specification.new do |spec|
 
   spec.files = Dir["{app,lib}/**/*", "MIT-LICENSE", "Rakefile", "README.md"]
 
-  spec.add_runtime_dependency 'administrate', '~> 0.14'
+  spec.add_runtime_dependency 'administrate', '~> 0.17'
   spec.add_runtime_dependency 'sassc', '~> 2.4'
 end


### PR DESCRIPTION
When I want to use this theme with latest `administrate` version (0.17) I got incompatibility error

```
Bundler could not find compatible versions for gem "administrate":
  In snapshot (Gemfile.lock):
    administrate (= 0.17.0)

  In Gemfile:
    administrate (~> 0.17.0)

    administrate-materialize-theme was resolved to 0.2.4, which depends on
      administrate (~> 0.14.0)

Running `bundle update` will rebuild your snapshot from scratch, using only
the gems in your Gemfile, which may resolve the conflict.
```

I just simply made a change on the dependency version. I don't know what else should I do. But I already run the test and it passed.
```
$ rspec
Run options:
  include {:focus=>true}
  exclude {:changes_filesystem=>true}

All examples were filtered out; ignoring {:focus=>true}

Randomized with seed 28602

Theme
Capybara starting Puma...
* Version 4.3.12 , codename: Mysterious Traveller
* Min threads: 0, max threads: 4
* Listening on tcp://127.0.0.1:51118
  checks that the theme is loaded

Finished in 1.82 seconds (files took 2.05 seconds to load)
1 example, 0 failures

Randomized with seed 28602
```